### PR TITLE
Pin dlss-capistrano to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :deployment do
   gem 'capistrano-passenger'
   gem 'capistrano-sidekiq'
   gem 'capistrano-shared_configs'
-  gem 'dlss-capistrano'
+  gem 'dlss-capistrano', '~> 3.5'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,7 +343,7 @@ DEPENDENCIES
   capistrano-sidekiq
   capybara (>= 2.15, < 4.0)
   chart-js-rails
-  dlss-capistrano
+  dlss-capistrano (~> 3.5)
   honeybadger
   http
   jbuilder (~> 2.5)


### PR DESCRIPTION
Do this because when dlss-capistrano 4.0 comes out, codebases that use both dlss-capistrano and capistrano-sidekiq without pinning the former will find it clobbering the sidekiq tasks from the latter, and that will cause confusion and woe.